### PR TITLE
playground - parity with kotlin variant

### DIFF
--- a/PingSDK.playground/Contents.swift
+++ b/PingSDK.playground/Contents.swift
@@ -1,7 +1,10 @@
 @testable import PingSDK_Sources
 
-ping(api: "https://httpbin.org/post", lat: 43.670890, lon: -79.389640, callback: { data in
-    if let res = String(data: data, encoding: .utf8) {
-        print(res)
+log(
+    api: "https://httpbin.org/post",
+    lat: 43.670890,
+    lon: -79.389640,
+    callback: { data in
+        print(data)
     }
-})
+)

--- a/PingSDK.playground/Sources/Ping.swift
+++ b/PingSDK.playground/Sources/Ping.swift
@@ -1,21 +1,21 @@
 import Foundation
 
-func ping(api: String, lat: Double = 0.0, lon: Double = 0.0, callback: @escaping (Data) -> Void) {
-    // prepare HTTP request
-    var req = URLRequest(url: URL(string: api)!)
-    req.httpMethod = "POST"
-    req.setValue("application/json", forHTTPHeaderField: "Accept")
-    req.setValue("application/json", forHTTPHeaderField: "Content-Type")
-    // set JSON payload
-    let payload = try? JSONSerialization.data(withJSONObject: [
+func log(
+    api: String,
+    lat: Double = 0.0,
+    lon: Double = 0.0,
+    time: Int64 = 0, // epoch timestamp in seconds
+    ext: String = "", // extra text payload
+    callback: @escaping (Any) -> Void
+) {
+    let payload: [String: Any] = [
         "lat": lat,
         "lon": lon,
-    ])
-    req.httpBody = payload
-    // init URL session
-    let task = URLSession.shared.dataTask(with: req) { (data, _, _) in
-        guard let data = data else { return }
-        return callback(data)
-    }
-    task.resume()
+        "time": time,
+        "ext": ext,
+    ]
+
+    // implement POST payload to API Server
+    // callback should happen after POST
+    return callback(payload)
 }


### PR DESCRIPTION
remove sample http request, add `time` and `ext` payload fields